### PR TITLE
Close #1: failed to create new database on flatpak installation

### DIFF
--- a/Disable-native-dialogs.patch
+++ b/Disable-native-dialogs.patch
@@ -1,0 +1,15 @@
+Workaround for Flatpak
+Will be fixed upstreammore elegant  with a command.line option
+
+diff --git a/lib/main.cpp b/lib/main.cpp
+index 5e12ade3..58b294d0 100644
+--- a/lib/main.cpp
++++ b/lib/main.cpp
+@@ -118,6 +118,7 @@ int main(int argc, char *argv[])
+ 		is_gui_app = true;
+ 	}
+ 
++	QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs, true);
+ #if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+ 	{
+ 		QString path;

--- a/de.hohnstaedt.xca.yaml
+++ b/de.hohnstaedt.xca.yaml
@@ -31,3 +31,5 @@ modules:
         path: 0001-Extend-linux-app-images-by-128-and-256-bit-PNG.patch
       - type: patch
         path: 0001-metainfo.xml-Replace-io.github.chris2511.xca.patch
+      - type: patch
+        path: Disable-native-dialogs.patch


### PR DESCRIPTION
Use native dialogs, hardcoded for flatpak installation

bot, build 