### PR TITLE
Close 602: Linux/Flatpak: default template TLS_server is missing

### DIFF
--- a/0001-Close-602-Linux-Flatpak-default-template-TLS_server-.patch
+++ b/0001-Close-602-Linux-Flatpak-default-template-TLS_server-.patch
@@ -1,0 +1,37 @@
+From 4d91738b1aac5cc46786f7d1882492b748ab27e0 Mon Sep 17 00:00:00 2001
+From: Christian Hohnstaedt <christian@hohnstaedt.de>
+Date: Thu, 24 Oct 2024 13:11:24 +0200
+Subject: [PATCH] Close 602: Linux/Flatpak: default template TLS_server is
+ missing
+
+Extend search for templates to /usr[/local]/share/xca"
+---
+ lib/db_temp.cpp | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/lib/db_temp.cpp b/lib/db_temp.cpp
+index 412531bf..0bd8ec51 100644
+--- a/lib/db_temp.cpp
++++ b/lib/db_temp.cpp
+@@ -33,9 +33,16 @@ db_temp::db_temp() : db_x509name("templates")
+ 	tmpl->setAsPreDefined();
+ 	predefs << tmpl;
+ 
++	const QString appname = QCoreApplication::applicationName();
++	QStringList appdata = QStandardPaths::standardLocations(
++	                      QStandardPaths::AppDataLocation);
++
+ 	foreach(QString d, QStandardPaths::standardLocations(
+-				QStandardPaths::AppDataLocation))
+-	{
++	                   QStandardPaths::AppDataLocation))
++			appdata << d.replace(appname, "xca");
++
++	foreach(const QString &d, appdata) {
++		qDebug() << "Loading templates from" << d;
+ 		QFileInfoList list = QDir(d).entryInfoList(
+ 				QStringList("*.xca"),
+ 				QDir::Files | QDir::NoSymLinks |
+-- 
+2.39.5 (Apple Git-154)
+

--- a/de.hohnstaedt.xca.yaml
+++ b/de.hohnstaedt.xca.yaml
@@ -27,3 +27,5 @@ modules:
       - type: archive
         url: https://github.com/chris2511/xca/releases/download/RELEASE.2.8.0/xca-2.8.0.tar.gz
         sha256: 87955987ad6e05ba3dcac826cd22f7d9cedf00e4a409a1931e94e5347e79a7d0
+      - type: patch
+        path: 0001-Close-602-Linux-Flatpak-default-template-TLS_server-.patch


### PR DESCRIPTION
Extend search for templates to /usr[/local]/share/xca"

bot, build
